### PR TITLE
Fix github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  TOOLCHAIN_VERSION: 23
-  GRADLE_JAVA_VERSION: 23
+  TOOLCHAIN_VERSION: 25
+  GRADLE_JAVA_VERSION: 21
   CLANG_LLVM_VERSION: 13.0.0
   CLANG_LLVM_BASE_URL: "https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/"
   JTREG_VERSION: 7.3.1+1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,9 +55,9 @@ jobs:
     needs: [build-jtreg]
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             TARGET: clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04
             ARCHIVE_EXT: "tar.xz"
             LIB_DIR: lib


### PR DESCRIPTION
Currently we use JDK 23 as both the JDK on which to run Gradle (sourced from oracle.com), and the JDK with which to build jextract (sourced from jdk.java.net).

However, neither of these sources support JDK 23 any more.

This PR proposes to change the build JDK to 25. Since the version of Gradle that we use doesn't support 25, we use 21 for running Gradle. JDK 21 is sourced from oracle.com (it is LTS there), and 25 is sourced from jdk.java.net. i.e. the source of either is not changed.

Finally, the current actions are configured to use ubuntu-20.04, since we have a binary available for that system from the llvm-project releases page on github. However, runners with that version of ubuntu seem to be in short supply, and a job I tried to run took more than 24 hours to be picked (I ended up just cancelling it). I've switched the script to use `ubuntu-latest`, which seems to work fine with the same binary, and is much more readily available as a runner.